### PR TITLE
Update application.html.haml

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,27 +1,27 @@
 !!! 5
 %html
-%head
-	%title Recipe App
-	= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
-	= javascript_include_tag 'application', 'data-turbolinks-track' => true
-	= csrf_meta_tags
-
-%body
-	%nav.navbar.navbar-default
+	%head
+		%title Recipe App
+		= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
+		= javascript_include_tag 'application', 'data-turbolinks-track' => true
+		= csrf_meta_tags
+	
+	%body
+		%nav.navbar.navbar-default
+			.container
+				.navbar-brand= link_to "Recipe Box", root_path
+	
+				- if user_signed_in?
+					%ul.nav.navbar-nav.navbar-right
+						%li= link_to "New Recipe", new_recipe_path
+						%li= link_to "Sign Out", destroy_user_session_path, method: :delete
+				- else
+					%ul.nav.navbar-nav.navbar-right
+						%li= link_to "Sign Up", new_user_registration_path
+						%li= link_to "Sign In", new_user_session_path
+	
 		.container
-			.navbar-brand= link_to "Recipe Box", root_path
-
-			- if user_signed_in?
-				%ul.nav.navbar-nav.navbar-right
-					%li= link_to "New Recipe", new_recipe_path
-					%li= link_to "Sign Out", destroy_user_session_path, method: :delete
-			- else
-				%ul.nav.navbar-nav.navbar-right
-					%li= link_to "Sign Up", new_user_registration_path
-					%li= link_to "Sign In", new_user_session_path
-
-	.container
-		- flash.each do |name, msg|
-			= content_tag :div, msg, class: "alert"
-
-		= yield
+			- flash.each do |name, msg|
+				= content_tag :div, msg, class: "alert"
+	
+			= yield


### PR DESCRIPTION
Just need to indent everything below %html, or the final rendered page will close your html element before the head and body elements, rather than properly nesting them. Among other possible effects, this appears to be the source of the issue lots of your youtube viewers have had, where clicking the add buttons to add ingredients or instructions while creating/editing recipes results in multiple text fields being added, instead of just one.
